### PR TITLE
Validation of cli args

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,6 @@ If you get an error try setting `-d localhost`
 - [x] Setup changelog generator (https://github.com/charmixer/auto-changelog-action) - currently creates pull requests
   - [ ] Should somehow create the changelog before release tag is created, so it gets baked in
 - [x] Infrastructure reference stack - includes prometheus, jaeger and grafana
+- [x] Validation of cli inputs with (https://github.com/go-playground/validator)[go-playground] lib
 - [ ] README.md update with guides
 - [ ] HTTP Client with easy tracing propagation

--- a/cmd/oas.go
+++ b/cmd/oas.go
@@ -10,9 +10,7 @@ import (
 	"github.com/charmixer/oas/exporter"
 )
 
-type oasCmd struct {
-	// version   bool `short:"v" long:"version" description:"display version"`
-}
+type oasCmd struct{}
 
 func (v *oasCmd) Execute(args []string) error {
 	router := router.NewRouter(env.Env.Build.Name, Application.Description, env.Env.Build.Version)

--- a/endpoint/docs/docs.go
+++ b/endpoint/docs/docs.go
@@ -11,8 +11,8 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 
-	"github.com/charmixer/golang-api-template/env"
 	"github.com/charmixer/golang-api-template/endpoint/problem"
+	"github.com/charmixer/golang-api-template/env"
 	"github.com/charmixer/oas/api"
 
 	"github.com/charmixer/golang-api-template/endpoint"

--- a/endpoint/health/ready.go
+++ b/endpoint/health/ready.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/charmixer/oas/api"
 
-	"github.com/charmixer/golang-api-template/env"
 	"github.com/charmixer/golang-api-template/endpoint"
 	"github.com/charmixer/golang-api-template/endpoint/problem"
+	"github.com/charmixer/golang-api-template/env"
 	hc "github.com/charmixer/golang-api-template/health"
 
 	"go.opentelemetry.io/otel"

--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -16,35 +16,6 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-/*
-var (
-	validate *validator.Validate
-	locale   string
-	trans    ut.Translator
-)
-
-func init() {
-	validate = validator.New()
-
-	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
-		name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
-
-		if name == "-" {
-			return ""
-		}
-
-		return name
-	})
-
-	locale = "en"
-
-	enTranslator := en.New()
-	uni := ut.New(enTranslator, enTranslator)
-
-	trans, _ = uni.GetTranslator(locale)
-	en_translations.RegisterDefaultTranslations(validate, trans)
-}*/
-
 func WithRequestValidation(ctx context.Context, i interface{}) error {
 	tr := otel.Tracer("request")
 	ctx, span := tr.Start(ctx, "request-validation")

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -1,0 +1,38 @@
+package validation
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/go-playground/locales/en"
+	ut "github.com/go-playground/universal-translator"
+	"github.com/go-playground/validator/v10"
+	en_translations "github.com/go-playground/validator/v10/translations/en"
+)
+
+const locale = "en"
+
+var (
+	Validate    *validator.Validate
+	Translation ut.Translator
+)
+
+func init() {
+	Validate = validator.New()
+
+	Validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
+		name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+
+		if name == "-" {
+			return ""
+		}
+
+		return name
+	})
+
+	enTranslator := en.New()
+	uni := ut.New(enTranslator, enTranslator)
+
+	Translation, _ = uni.GetTranslator(locale)
+	en_translations.RegisterDefaultTranslations(Validate, Translation)
+}


### PR DESCRIPTION
- Moves validation to it's own package
- Enables validation of cli args by using `validate` tag on structs.

*Will break implementations if `go-flags` and `envconfig` isn't upgraded to latest versions in mod file.*